### PR TITLE
Fix usage of external input

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -275,11 +275,11 @@ int main(int argc, const char * argv[]) {
 			}
 
 			// here we have data in the buffer - lets encrypt them
-			W128b plain, state;
-			long int iter2comp = max(iters, (long int) ceil((float)bRead / N_BYTES));
+			W128b state;
+			long int iter2comp = min(iters, (long int) ceil((float)bRead / N_BYTES));
 
 			for(int k = 0; k < iter2comp; k++, blockCount++){
-				arr_to_W128b(memblock, N_BYTES * 16, plain);
+				arr_to_W128b(memblock, k * 16, state);
 
 				// encryption
 				if (useExternal) generator.applyExternalEnc(state, &coding, true);


### PR DESCRIPTION
Hi 
Computation of number of input blocks was wrong as well as used buffer and offset

Now code can be validated with input file:

echo 3243f6a8885a308d313198a2e0370734 6bc1bee22e409f96e93d7e117393172a|xxd -r -p > foo
./main --input-files foo --out-file foo.enc
cat foo.enc |xxd -p
=> 3925841d02dc09fbdc118597196a0b32 3ad77bb40d7a3660a89ecaf32466ef97
