### PR TITLE
Make it work with input fds

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -339,7 +339,7 @@ int tryMain(int argc, const char * argv[]) {
 		}
 
 		// Open reading file
-		ifstream inf(fileName.c_str(), ios::in | ios::binary | ios::ate);
+		ifstream inf(fileName.c_str(), ios::in | ios::binary);
 		if (inf.is_open()==false){
 			cerr << "Cannot open specified input file" << endl;
 			exit(3);
@@ -351,12 +351,6 @@ int tryMain(int argc, const char * argv[]) {
 		unsigned long long blockCount = 0;
 		char * memblock          = new char[buffSize];
 		char blockbuff[N_BYTES];
-
-		ifstream::pos_type size;
-		// get file size - ios::ate => we are at the end of the file
-		size = inf.tellg();
-		// move on the beginning
-		inf.seekg(0, ios::beg);
 
 		// time measurement of just the cipher operation
 		time_t cstart, cend;


### PR DESCRIPTION
Hi
Currently input file is opened with ios::ate to get its size, but this information is not used and this prevents to use fds as input.
This patch removes the ios::ate flag and the unused code.
This allows e.g. to use it as:

```
./main --input-files <(echo 6bc1bee22e409f96e93d7e117393172a|xxd -r -p) --out-file >(xxd -p)
```
