### PR TITLE
Fix compilation error on older setups

### DIFF
--- a/NTLUtils.cpp
+++ b/NTLUtils.cpp
@@ -19,6 +19,7 @@
 #include <iomanip>
 #include <iostream>
 #include <fstream>
+#include <stdexcept>
 #include <boost/io/ios_state.hpp>
 
 NTL_CLIENT


### PR DESCRIPTION
On e.g. Debian stable, we get the following compilation error:

```
[ 37%] Building CXX object CMakeFiles/main.dir/NTLUtils.cpp.o
Whitebox-crypto-AES/NTLUtils.cpp: In function 'int char2int(char)':
Whitebox-crypto-AES/NTLUtils.cpp:255:8: error: 'invalid_argument' is not a member of 'std'
  throw std::invalid_argument("Invalid input string");
        ^
CMakeFiles/main.dir/build.make:238: recipe for target 'CMakeFiles/main.dir/NTLUtils.cpp.o' failed
make[2]: *** [CMakeFiles/main.dir/NTLUtils.cpp.o] Error 1
CMakeFiles/Makefile2:60: recipe for target 'CMakeFiles/main.dir/all' failed
make[1]: *** [CMakeFiles/main.dir/all] Error 2
Makefile:76: recipe for target 'all' failed
make: *** [all] Error 2
```

The patch solves the problem and doesn't hurt on newer systems where compilation was fine.
