### PR TITLE
Fixed table generation for main executable - encoding must be generated

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -311,6 +311,9 @@ int tryMain(int argc, const char * argv[]) {
 		WBAESGenerator generator;
 		WBAES * genAES = new WBAES;
 		ExtEncoding coding;
+		// Generate new encoding.
+		cout << "Generating External encoding, identity: " << useExternal << "..." << endl;
+		generator.generateExtEncoding(&coding, useExternal ? 0 : WBAESGEN_EXTGEN_ID);
 
 		if (inTables.empty() && keyToUse != NULL) {
 			cout << "Generating WB-AES instance..." << endl;
@@ -319,11 +322,6 @@ int tryMain(int argc, const char * argv[]) {
 			generator.generateTables(keyToUse, KEY_SIZE_16, genAES, &coding, false);
 			time(&end);
 			cout << "Generating AES tables took: [" << (end - start) << "] seconds" << endl;
-
-			// Generate new encoding.
-			cout << "Generating External encoding, identity: " << useExternal << "..." << endl;
-			generator.generateExtEncoding(&coding, useExternal ? 0 : WBAESGEN_EXTGEN_ID);
-
 		} else {
 			cout << "Loading stored AES tables: " << useExternal << endl;
 			time(&start);


### PR DESCRIPTION
Compiled main executable fails when called like this:
`./main --decrypt=0 --use-key 000102030405060708090A0B0C0D0E0F --input-files my_plaintext_file --out-file my_encrypted_file`
NTL complains about "matrix mul: dimension mismatch" during table generation:
https://github.com/ph4r05/Whitebox-crypto-AES/blob/master/WBAESGenerator.cpp#L341
Here two matrices are multiplied but first one is not initialized (0 rows, 0 cols) because WBAESGenerator::generateExtEncoding is not called on it before.