### PR TITLE
Change "master" reference to "main" for Google repo

### DIFF
--- a/CMakeLists-gtest.txt.in
+++ b/CMakeLists-gtest.txt.in
@@ -4,7 +4,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG master
+    GIT_TAG main
     SOURCE_DIR "${CMAKE_BINARY_DIR}/googletest-src"
     BINARY_DIR "${CMAKE_BINARY_DIR}/googletest-build"
     CONFIGURE_COMMAND ""


### PR DESCRIPTION
Google has changed all "master" references to "main". This change will allow the project to properly build.